### PR TITLE
Chart highlight bug

### DIFF
--- a/src/main/java/com/duckblade/osrs/sailing/features/charting/SeaChartOverlay.java
+++ b/src/main/java/com/duckblade/osrs/sailing/features/charting/SeaChartOverlay.java
@@ -118,12 +118,13 @@ public class SeaChartOverlay
 			SeaChartTask task = tracked.getValue();
 
 			boolean completed = isTaskCompleted(task);
-			if (completed && mode == SailingConfig.ShowChartsMode.UNCHARTED)
+			if ((completed && mode == SailingConfig.ShowChartsMode.UNCHARTED) ||
+				(!completed && mode == SailingConfig.ShowChartsMode.CHARTED))
 			{
 				continue;
 			}
 
-			Color color = isTaskCompleted(task) ? Color.YELLOW : Color.GREEN;
+			Color color = completed ? colorCharted : colorUncharted;
 			OverlayUtil.renderActorOverlayImage(g, npc, taskIndex.getTaskSprite(task), color, npc.getLogicalHeight() / 2);
 		}
 


### PR DESCRIPTION
## Fix diving highlight colors not respecting config settings (#36)

### Solution
- Updated NPC rendering to use `colorCharted` and `colorUncharted` from config (same as GameObjects)

Addresses #36 
