### PR TITLE
Fix sail highlight not clearing when using Wind Catcher or Gale Catcher (#33)

### DIFF
--- a/src/main/java/com/duckblade/osrs/sailing/features/LuffOverlay.java
+++ b/src/main/java/com/duckblade/osrs/sailing/features/LuffOverlay.java
@@ -30,6 +30,7 @@ public class LuffOverlay
 
 	private static final String CHAT_LUFF_AVAILABILE = "You feel a gust of wind.";
 	private static final String CHAT_LUFF_PERFORMED = "You trim the sails, catching the wind for a burst of speed!";
+	private static final String CHAT_LUFF_STORED = "You trim the sails, catching the wind and storing a wind mote in your helm.";
 	private static final String CHAT_LUFF_ENDED = "The wind dies down and your sails with it.";
 
 	private final Client client;
@@ -68,7 +69,7 @@ public class LuffOverlay
 		{
 			needLuff = true;
 		}
-		else if (CHAT_LUFF_PERFORMED.equals(msg) || CHAT_LUFF_ENDED.equals(msg))
+		else if (CHAT_LUFF_PERFORMED.equals(msg) || CHAT_LUFF_STORED.equals(msg) || CHAT_LUFF_ENDED.equals(msg))
 		{
 			needLuff = false;
 		}


### PR DESCRIPTION
## Solution

• Added detection for the "storing a wind mote" chat message that appears when using Wind Catcher or Gale Catcher

Addresses #33 