### PR TITLE
Fix sail highlighting bugs

### DIFF
--- a/src/main/java/com/duckblade/osrs/sailing/features/facilities/LuffOverlay.java
+++ b/src/main/java/com/duckblade/osrs/sailing/features/facilities/LuffOverlay.java
@@ -72,13 +72,10 @@ public class LuffOverlay
 	@Subscribe
 	public void onWorldViewUnloaded(WorldViewUnloaded e)
 	{
-		if (!e.getWorldView().isTopLevel())
+		if (!e.getWorldView().isTopLevel() &&
+			e.getWorldView() == client.getLocalPlayer().getWorldView())
 		{
-			if (client.getLocalPlayer() == null ||
-				e.getWorldView().getId() == client.getLocalPlayer().getWorldView().getId())
-			{
-				needLuff = false;
-			}
+			needLuff = false;
 		}
 	}
 


### PR DESCRIPTION
### CHANGES
• Fixed MAHOGANY sail tier having duplicate 3x8 (sloop) entries instead of 1x3 (raft) and 2x5 (skiff)
  - Sails on Mahogany rafts and skiffs can now be properly recognized and highlighted
  - Include boat-type handling from @lclc98’s work in #24 (`Add each boat type`), so all boat types are treated consistently.
  - Fixes #29
  - Fixes #47

### Credits / Related PRs

- Boat-type logic is based on @lclc98’s PR #24, which has been cherry-picked into this branch with authorship preserved.
- If this PR is merged, #24 can either be closed or rebased as the maintainer prefers.
