### PR TITLE
Fixing issue where Prioritize Cargo Hold would "red x" examine on oth…

### DIFF
--- a/src/main/java/com/duckblade/osrs/sailing/features/mes/PrioritizeCargoHold.java
+++ b/src/main/java/com/duckblade/osrs/sailing/features/mes/PrioritizeCargoHold.java
@@ -16,6 +16,7 @@ import net.runelite.api.Client;
 import net.runelite.api.Menu;
 import net.runelite.api.MenuEntry;
 import net.runelite.api.events.PostMenuSort;
+import net.runelite.api.gameval.VarbitID;
 import net.runelite.client.eventbus.Subscribe;
 
 @Slf4j


### PR DESCRIPTION
…er people's boats

Prioritize Cargo Hold as written would prioritize the examine option on other people's boats. Obviously this isn't the intended behavior for this setting. This change would fix that in a simple way, copying a line from DeprioSailsOffHelm.java.

I believe the intended use of this setting is to prioritize the cargo over crew members when you're salvaging, which this fix wouldn't really interfere with.

However one thing this will do is change the behavior of the setting if you're at the helm and want to open the cargo hold from the helm.

I think the red-x on other people's ships when trying to navigate is a *much* bigger issue (e.g. doing trials) than the change in behavior this would have for what's probably an unusual use case (clicking your cargo hold from the helm)

Closes #39 
Closes #55 