### PR TITLE
Cargo hold storage count fixing

### DIFF
--- a/src/main/java/com/duckblade/osrs/sailing/features/CargoHoldTracker.java
+++ b/src/main/java/com/duckblade/osrs/sailing/features/CargoHoldTracker.java
@@ -210,7 +210,7 @@ public class CargoHoldTracker
 		{
 			if (item != null)
 			{
-				trackedInv.add(item.getId(), item.getQuantity());
+				trackedInv.add(item.getId(), 1);
 			}
 		}
 


### PR DESCRIPTION
## FIX
- Store each slot as 1 in onItemContainerChanged (line 213) instead of storing quantities
- Fixes #78

### Note:

I tested this against storing cannonballs, salvage, repair kits. The stackable things. Seems to be working correctly basing it on this.

<img width="429" height="465" alt="image" src="https://github.com/user-attachments/assets/fda75393-2371-4229-ba8e-e5bc42bc25c7" />

