### PR TITLE
Cancel reverse beep on certain game states

### DIFF
--- a/src/main/java/com/duckblade/osrs/sailing/features/reversebeep/ReverseBeep.java
+++ b/src/main/java/com/duckblade/osrs/sailing/features/reversebeep/ReverseBeep.java
@@ -73,11 +73,12 @@ public class ReverseBeep implements PluginLifecycleComponent
 
     @Subscribe
     public void onGameStateChanged(GameStateChanged e) {
-        if (e.getGameState() == GameState.HOPPING
+        if ((e.getGameState() == GameState.HOPPING
                 || e.getGameState() == GameState.CONNECTION_LOST
                 || e.getGameState() == GameState.LOGIN_SCREEN
                 || e.getGameState() == GameState.LOGIN_SCREEN_AUTHENTICATOR
                 || e.getGameState() == GameState.UNKNOWN)
+                && beepTask != null)
         {
             beepTask.cancel(false);
             beepTask = null;


### PR DESCRIPTION
When a player logs out, hops, loses connection, or is in an unknown game state, the reverse beep sound stops