### PR TITLE
Fix Cargo Hold Assignment in Boarding UI

### DIFF
--- a/src/main/java/com/duckblade/osrs/sailing/features/facilities/CargoHoldTracker.java
+++ b/src/main/java/com/duckblade/osrs/sailing/features/facilities/CargoHoldTracker.java
@@ -81,13 +81,13 @@ public class CargoHoldTracker
 		"Woooo wooo wooooo woooo."
 	);
 
-	private static final Map<Integer, Integer> CARGOHOLD_ID_TO_BOAT_SLOT = ImmutableMap.of(
-		InventoryID.SAILING_BOAT_1_CARGOHOLD, 1,
-		InventoryID.SAILING_BOAT_2_CARGOHOLD, 2,
-		InventoryID.SAILING_BOAT_3_CARGOHOLD, 3,
-		InventoryID.SAILING_BOAT_4_CARGOHOLD, 4,
-		InventoryID.SAILING_BOAT_5_CARGOHOLD, 5
-	);
+	private static final Map<Integer, Integer> CARGOHOLD_ID_TO_BOAT_SLOT = ImmutableMap.<Integer, Integer>builder()
+			.put(InventoryID.SAILING_BOAT_1_CARGOHOLD, 1)
+			.put(InventoryID.SAILING_BOAT_2_CARGOHOLD, 2)
+			.put(InventoryID.SAILING_BOAT_3_CARGOHOLD, 3)
+			.put(InventoryID.SAILING_BOAT_4_CARGOHOLD, 4)
+			.put(InventoryID.SAILING_BOAT_5_CARGOHOLD, 5)
+			.build();
 
 	private static final char CONFIG_DELIMITER_PAIRS = ';';
 	private static final char CONFIG_DELIMITER_KV = ':';


### PR DESCRIPTION
Fixes #228 
## Changes
- `onItemContainerChanged` fires when the boat boarding UI is open for all non-empty boat cargo holds
<img width="401" height="331" alt="image" src="https://github.com/user-attachments/assets/34bd3d37-9274-4386-8fd4-6d5c7b8dfc26" />

- Write the available cargo hold inventories to their corresponding boat slots using mapping `CARGOHOLD_ID_TO_BOAT_SLOT`
- Change `cargoHoldItems` to be 1-indexed instead of 0-indexed matching varbit values