### PR TITLE
Cargo Hold Tracker: Restore Deposit-All Tracking

### DIFF
--- a/src/main/java/com/duckblade/osrs/sailing/features/facilities/CargoHoldTracker.java
+++ b/src/main/java/com/duckblade/osrs/sailing/features/facilities/CargoHoldTracker.java
@@ -342,22 +342,24 @@ public class CargoHoldTracker
 	@Subscribe
 	public void onMenuOptionClicked(MenuOptionClicked e)
 	{
-		if (e.getMenuOption().contains("Withdraw") || e.getMenuOption().contains("Deposit"))
+		if (!e.getMenuOption().contains("Withdraw") && !e.getMenuOption().contains("Deposit"))
 		{
-			Widget cargoHoldWidget = client.getWidget(InterfaceID.SailingBoatCargohold.UNIVERSE); // todo confirm
-			if (cargoHoldWidget != null && !cargoHoldWidget.isHidden())
-			{
-				pendingInventoryAction = INVENTORY_DELTA_MAX_DELAY;
-				memoizedInventory = getInventoryMap();
-				log.debug("queued pendingInventoryAction with inventory {}", memoizedInventory);
-			}
+			return;
 		}
-		else if(e.getMenuOption().equals("Deposit-all"))
+		if (e.getMenuOption().equals("Deposit-all"))
 		{
 			beginSfxOverrideIfMuted();
 			depositAllTicksRemaining = DEPOSIT_ALL_MAX_TICKS_TIMEOUT;
 			initialDepositAllInventory = getInventoryMap();
 			log.debug("Initial deposit-all player inventory {}", initialDepositAllInventory);
+		}
+
+		Widget cargoHoldWidget = client.getWidget(InterfaceID.SailingBoatCargohold.UNIVERSE); // todo confirm
+		if (cargoHoldWidget != null && !cargoHoldWidget.isHidden())
+		{
+			pendingInventoryAction = INVENTORY_DELTA_MAX_DELAY;
+			memoizedInventory = getInventoryMap();
+			log.debug("queued pendingInventoryAction with inventory {}", memoizedInventory);
 		}
 	}
 

--- a/src/main/java/com/duckblade/osrs/sailing/features/facilities/CargoHoldTracker.java
+++ b/src/main/java/com/duckblade/osrs/sailing/features/facilities/CargoHoldTracker.java
@@ -36,12 +36,15 @@ import net.runelite.api.events.GameTick;
 import net.runelite.api.events.ItemContainerChanged;
 import net.runelite.api.events.MenuOptionClicked;
 import net.runelite.api.events.OverheadTextChanged;
+import net.runelite.api.Preferences;
+import net.runelite.api.events.SoundEffectPlayed;
 import net.runelite.api.events.StatChanged;
 import net.runelite.api.events.WidgetLoaded;
 import net.runelite.api.gameval.InterfaceID;
 import net.runelite.api.gameval.InventoryID;
 import net.runelite.api.gameval.ItemID;
 import net.runelite.api.gameval.VarbitID;
+import net.runelite.api.gameval.VarPlayerID;
 import net.runelite.api.widgets.Widget;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
@@ -118,6 +121,14 @@ public class CargoHoldTracker
 
 	private int lastXp;
 	private boolean pendingJenkinsAction;
+	//sfx variables
+	private boolean sfxVolumeOverridden = false;
+	private int previousSfxVolume = -1;
+	private static final int SFX_OVERRIDE_VOLUME = 1;
+	private static final int SFX_DEPOSIT_ALL_ID = 10905;
+	private static final int DEPOSIT_ALL_MAX_TICKS_TIMEOUT = 12;
+	private int depositAllTicksRemaining;
+	private Multiset<Integer> initialDepositAllInventory;
 
 	@Inject
 	public CargoHoldTracker(Client client, ConfigManager configManager, BoatTracker boatTracker, CourierTaskTracker courierTaskTracker)
@@ -283,6 +294,11 @@ public class CargoHoldTracker
 	{
 		pendingJenkinsAction = false;
 
+		if (--depositAllTicksRemaining <= 0)
+		{
+				resetDepositAllState();
+		}
+
 		if (--pendingInventoryAction < 0)
 		{
 			sawItemContainerUpdate = false;
@@ -326,17 +342,22 @@ public class CargoHoldTracker
 	@Subscribe
 	public void onMenuOptionClicked(MenuOptionClicked e)
 	{
-		if (!e.getMenuOption().contains("Withdraw") && !e.getMenuOption().contains("Deposit"))
+		if (e.getMenuOption().contains("Withdraw") || e.getMenuOption().contains("Deposit"))
 		{
-			return;
+			Widget cargoHoldWidget = client.getWidget(InterfaceID.SailingBoatCargohold.UNIVERSE); // todo confirm
+			if (cargoHoldWidget != null && !cargoHoldWidget.isHidden())
+			{
+				pendingInventoryAction = INVENTORY_DELTA_MAX_DELAY;
+				memoizedInventory = getInventoryMap();
+				log.debug("queued pendingInventoryAction with inventory {}", memoizedInventory);
+			}
 		}
-
-		Widget cargoHoldWidget = client.getWidget(InterfaceID.SailingBoatCargohold.UNIVERSE); // todo confirm
-		if (cargoHoldWidget != null && !cargoHoldWidget.isHidden())
+		else if(e.getMenuOption().equals("Deposit-all"))
 		{
-			pendingInventoryAction = INVENTORY_DELTA_MAX_DELAY;
-			memoizedInventory = getInventoryMap();
-			log.debug("queued pendingInventoryAction with inventory {}", memoizedInventory);
+			beginSfxOverrideIfMuted();
+			depositAllTicksRemaining = DEPOSIT_ALL_MAX_TICKS_TIMEOUT;
+			initialDepositAllInventory = getInventoryMap();
+			log.debug("Initial deposit-all player inventory {}", initialDepositAllInventory);
 		}
 	}
 
@@ -353,6 +374,25 @@ public class CargoHoldTracker
 		if (itemsChild != null && Objects.equals(itemsChild.getText(), WIDGET_TEXT_CARGO_HOLD_EMPTY))
 		{
 			cargoHold().clear();
+		}
+	}
+
+	@Subscribe
+	public void onSoundEffectPlayed(SoundEffectPlayed e)
+	{
+		if (sfxVolumeOverridden)
+		{
+			e.consume();
+		}
+		if (e.getSoundId() == SFX_DEPOSIT_ALL_ID && depositAllTicksRemaining > 0)
+		{
+
+			Multiset<Integer> deposit = Multisets.difference(initialDepositAllInventory, getInventoryMap()); // items missing from inv that were in prior snapshot
+			Multiset<Integer> cargoHoldToUpdate = cargoHold();
+			deposit.entrySet().forEach(entry -> cargoHoldToUpdate.add(entry.getElement(), entry.getCount()));
+			log.debug("updated cargo hold from deposit-all inventory delta {}", cargoHoldToUpdate);
+			writeToConfig();
+			resetDepositAllState();
 		}
 	}
 
@@ -497,4 +537,41 @@ public class CargoHoldTracker
 		log.trace("wrote cargoHold {} to config {} = {}", boatSlot, key, configValue);
 	}
 
+	private void setSfxVolume(int vol)
+	{
+		Preferences preferences = client.getPreferences();
+		preferences.setSoundEffectVolume(vol);
+
+		client.getVarps()[VarPlayerID.OPTION_SOUNDS] = vol;
+		client.queueChangedVarp(VarPlayerID.OPTION_SOUNDS);
+	}
+
+	private void beginSfxOverrideIfMuted()
+	{
+		Preferences preferences = client.getPreferences();
+		int current = preferences.getSoundEffectVolume();
+		if (current != 0 || sfxVolumeOverridden)
+		{
+			return;
+		}
+
+		previousSfxVolume = current;
+		sfxVolumeOverridden = true;
+
+		setSfxVolume(SFX_OVERRIDE_VOLUME);
+	}
+
+	private void resetDepositAllState()
+	{
+		if (sfxVolumeOverridden) {
+			// if we never captured previous, default to muted
+			int restore = previousSfxVolume >= 0 ? previousSfxVolume : 0;
+			setSfxVolume(restore);
+			sfxVolumeOverridden = false;
+			previousSfxVolume = -1;
+		}
+
+		depositAllTicksRemaining = 0;
+		initialDepositAllInventory = null;
+	}
 }


### PR DESCRIPTION
Closes #177 
![java_MIIZeoZ1et](https://github.com/user-attachments/assets/0d669572-e927-4790-9c05-faf578aaecb5)


- Uses `onSoundEffectPlayed` event as the source of truth for the confirmation of a successful quick-deposit
   - Sound effect with ID = 10905 is played upon a successful quick deposit (sent from server)
   - This SFX event is only fired when the client is not muted so we unmute the client to _enable_ the event to post
   - uses `consume` method to avoid playing SFX for players who play with 0 volume
- Upon clicking `Deposit-all` unmute the client anticipating SFX with ID = 10905 and memoize player inventory
- Durable through inventory changes that occur between clicking `Deposit-all` and the deposit action

