### PR TITLE
Fix sail trim highlight fallback after Red Reef update

### DIFF
--- a/src/main/java/com/duckblade/osrs/sailing/features/facilities/LuffOverlay.java
+++ b/src/main/java/com/duckblade/osrs/sailing/features/facilities/LuffOverlay.java
@@ -5,6 +5,7 @@ import com.duckblade.osrs.sailing.features.util.BoatTracker;
 import com.duckblade.osrs.sailing.features.util.SailingUtil;
 import com.duckblade.osrs.sailing.model.Boat;
 import com.duckblade.osrs.sailing.module.PluginLifecycleComponent;
+import com.google.common.collect.ImmutableSet;
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics2D;
@@ -14,6 +15,9 @@ import javax.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.GameObject;
+import net.runelite.api.GraphicsObject;
+import net.runelite.api.coords.LocalPoint;
+import net.runelite.api.gameval.SpotanimID;
 import net.runelite.api.gameval.VarbitID;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
@@ -27,6 +31,15 @@ public class LuffOverlay
 	extends Overlay
 	implements PluginLifecycleComponent
 {
+	private static final int SAIL_VFX_DISTANCE = 512;
+
+	private static final ImmutableSet<Integer> FULL_WIND_SAIL_VFX_IDS = ImmutableSet.of(
+		SpotanimID.VFX_WIND_SAIL_RAFT01_FULL01,
+		SpotanimID.VFX_WIND_SAIL_SMALL01_FULL01,
+		SpotanimID.VFX_WIND_SAIL_LARGE01_FULL01,
+		SpotanimID.VFX_WIND_SAIL_3X10_01
+	);
+
 	private final Client client;
 	private final SailingConfig config;
 	private final BoatTracker boatTracker;
@@ -71,7 +84,7 @@ public class LuffOverlay
 			return null;
 		}
 
-		if (client.getVarbitValue(VarbitID.SAILING_BOAT_TIME_TRIM_WINDOW) == 0)
+		if (!isTrimWindowActive(sail))
 		{
 			return null;
 		}
@@ -92,5 +105,37 @@ public class LuffOverlay
 		}
 
 		return null;
+	}
+
+	private boolean isTrimWindowActive(GameObject sail)
+	{
+		if (client.getVarbitValue(VarbitID.SAILING_BOAT_TIME_TRIM_WINDOW) > 0 ||
+			client.getServerVarbitValue(VarbitID.SAILING_BOAT_TIME_TRIM_WINDOW) > 0)
+		{
+			return true;
+		}
+
+		// The Red Reef update appears to leave this varbit unset while showing the trim window via full-wind sail vfx.
+		return hasFullWindSailVfx(sail);
+	}
+
+	private boolean hasFullWindSailVfx(GameObject sail)
+	{
+		LocalPoint sailLocation = sail.getLocalLocation();
+		for (GraphicsObject graphicsObject : sail.getWorldView().getGraphicsObjects())
+		{
+			LocalPoint graphicsLocation = graphicsObject.getLocation();
+			if (!FULL_WIND_SAIL_VFX_IDS.contains(graphicsObject.getId()) ||
+				graphicsObject.finished() ||
+				graphicsLocation == null ||
+				sailLocation.distanceTo(graphicsLocation) > SAIL_VFX_DISTANCE)
+			{
+				continue;
+			}
+
+			return true;
+		}
+
+		return false;
 	}
 }

--- a/src/main/java/com/duckblade/osrs/sailing/features/facilities/LuffOverlay.java
+++ b/src/main/java/com/duckblade/osrs/sailing/features/facilities/LuffOverlay.java
@@ -14,6 +14,7 @@ import javax.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.GameObject;
+import net.runelite.api.gameval.VarbitID;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
@@ -70,8 +71,7 @@ public class LuffOverlay
 			return null;
 		}
 
-		// Core behaviour: only show when the luff action is actually available
-		if (!sail.isOpShown(0))
+		if (client.getVarbitValue(VarbitID.SAILING_BOAT_TIME_TRIM_WINDOW) == 0)
 		{
 			return null;
 		}


### PR DESCRIPTION
## Summary

Fixes sail trim highlighting after the Red Reef update by using the trim-window varbit and adding a fallback for the changed menu action state.

## Why

The existing trim detection could stop matching the current in-game interaction state, so eligible sails were no longer highlighted reliably when the trim action was available.

## Testing

- Ran `./gradlew test` with the Homebrew JDK 11 runtime
- Launched RuneLite from IntelliJ IDEA using the Homebrew JDK 11 runtime and manually tested the plugin in the RuneLite development environment
